### PR TITLE
Allow only numbers in phone number field

### DIFF
--- a/src/features/auth/LoginModal.tsx
+++ b/src/features/auth/LoginModal.tsx
@@ -33,7 +33,7 @@ export const LoginModal = (): ReactElement => {
   };
 
   const onPhoneChange: ChangeEventHandler<HTMLInputElement> = (e) => {
-    const val = e.currentTarget.value;
+    const val = e.currentTarget.value.replace(/\D/g, "");
     if (val.length < 11) {
       setPhN(val);
     }


### PR DESCRIPTION
No longer allows user to enter non-numeric text in the phone number field during SignUp / Login.